### PR TITLE
Support BlackBox 6.0 and DBThreadSafe 3.1

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -24,17 +24,17 @@ jobs:
         include:
           - destination: "platform=iOS Simulator"
             platform: ios
-            device: "iPhone 16"
+            device: "iPhone 17"
             system_prefix: "iOS"
           - destination: "platform=OS X"
             platform: macos
           - destination: "platform=tvOS Simulator"
             platform: tvos
-            device: "Apple TV"
+            device: "Apple TV 4K (3rd generation)"
             system_prefix: "tvOS"
           - destination: "platform=watchOS Simulator"
             platform: watchos
-            device: "Apple Watch Ultra 2 (49mm)"
+            device: "Apple Watch Ultra 3 (49mm)"
             system_prefix: "watchOS"
 
     steps:
@@ -71,6 +71,7 @@ jobs:
           -scheme ${{ env.SCHEME }}
           -destination '${{ steps.select-destination.outputs.dest }}'
           -quiet
+          SWIFT_SUPPRESS_WARNINGS=NO
 
       - name: Test
         run: >
@@ -78,6 +79,7 @@ jobs:
           -scheme ${{ env.SCHEME }}
           -destination '${{ steps.select-destination.outputs.dest }}'
           -quiet
+          SWIFT_SUPPRESS_WARNINGS=NO
 
   # This allows us to have a branch protection rule for tests and deploys with matrix
   status-for-matrix:

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "eff767db7db9a95ae3ad14790c409877b532a3f99f1c375a87de5e10993eca1f",
+  "originHash" : "999a299fd264b5899058523ebd21119071aa633a27620fa5ba6a0922e4c643f3",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/dodobrands/BlackBox",
       "state" : {
-        "revision" : "6d4094c504b9e05d63298d93507386ef70f1d7b9",
-        "version" : "4.1.0"
+        "revision" : "18d1d64ba01b334acb5cc8d0b963d49a30f59a74",
+        "version" : "6.0.0"
       }
     },
     {
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/dodobrands/DBThreadSafe-ios",
       "state" : {
-        "revision" : "98f11ae07f2764e4228bf55c18c48e04a16b18bd",
-        "version" : "2.3.0"
+        "revision" : "0548278893bb62afab333d697aaf0c80931401c7",
+        "version" : "3.1.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:6.0
+// swift-tools-version:6.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -21,7 +21,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         .package(
             url: "https://github.com/dodobrands/BlackBox",
-            .upToNextMajor(from: "4.0.1")
+            .upToNextMajor(from: "6.0.0")
         ),
         .package(
             url: "https://github.com/firebase/firebase-ios-sdk",
@@ -29,7 +29,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/dodobrands/DBThreadSafe-ios",
-            .upToNextMajor(from: "2.0.0")
+            .upToNextMajor(from: "3.1.0")
         )
     ],
     targets: [
@@ -41,6 +41,9 @@ let package = Package(
                 "BlackBox",
                 .product(name: "FirebasePerformance", package: "firebase-ios-sdk"),
                 .product(name: "DBThreadSafe", package: "DBThreadSafe-ios")
+            ],
+            swiftSettings: [
+                .treatAllWarnings(as: .error)
             ]
         ),
         .testTarget(
@@ -49,6 +52,9 @@ let package = Package(
                 .targetItem(name: targetName, condition: nil),
                 "BlackBox",
                 .product(name: "FirebasePerformance", package: "firebase-ios-sdk")
+            ],
+            swiftSettings: [
+                .treatAllWarnings(as: .error)
             ]
         ),
     ],

--- a/Sources/BlackBoxFirebasePerformance/FirebasePerformanceLogger.swift
+++ b/Sources/BlackBoxFirebasePerformance/FirebasePerformanceLogger.swift
@@ -34,8 +34,8 @@ public class FirebasePerformanceLogger: BBLoggerProtocol {
         let traceName = name(of: event, forMetric: false)
         guard let trace = Performance.startTrace(name: traceName) else { return }
         
-        event.userInfo.map {
-            self.setMetricsOrAddAttributes(to: trace, from: $0)
+        if let userInfo = event.userInfo {
+            setMetricsOrAddAttributes(to: trace, from: userInfo)
         }
         incrementMetricForParentEvent(of: event)
         
@@ -47,8 +47,8 @@ public class FirebasePerformanceLogger: BBLoggerProtocol {
         
         guard let trace = traces.read ({ $0[id] })  else { return }
         
-        event.userInfo.map {
-            self.setMetricsOrAddAttributes(to: trace, from: $0)
+        if let userInfo = event.userInfo {
+            setMetricsOrAddAttributes(to: trace, from: userInfo)
         }
         
         trace.stop()
@@ -164,7 +164,6 @@ extension FirebasePerformanceLogger {
 
 #else
 
-import Foundation
 import BlackBox
 
 @available(*, unavailable, message: "FirebasePerformanceLogger is only available on iOS and tvOS when Firebase Performance SDK is present.")

--- a/Tests/BlackBoxFirebasePerformanceTests/BlackBoxFirebasePerformanceTests.swift
+++ b/Tests/BlackBoxFirebasePerformanceTests/BlackBoxFirebasePerformanceTests.swift
@@ -6,7 +6,6 @@
 //
 
 import XCTest
-import BlackBox
 @testable import BlackBoxFirebasePerformance
 
 class BlackBoxFirebasePerformanceTests: XCTestCase {


### PR DESCRIPTION
## Краткое описание

Обновил пакет для совместимости с релизами BlackBox 6.0.0 и DBThreadSafe-ios 3.1.0, чтобы зависимость можно было резолвить без branch/revision pin.

## Ключевые изменения

- обновил ограничения версий в `Package.swift` до BlackBox 6.0.0 и DBThreadSafe-ios 3.1.0
- включил warnings-as-errors для library target и test target
- обновил CI под Xcode 26 и актуальные устройства/рантаймы для GitHub-hosted runner
- добавил `SWIFT_SUPPRESS_WARNINGS=NO` в build/test шаги CI, чтобы warnings-as-errors работал корректно с пакетными зависимостями

## Дополнительные изменения

- обновил `Package.resolved` на релизные версии зависимостей
- убрал мелкие предупреждения в исходниках и тестах, чтобы сборка проходила с новым режимом

-------