### PR TITLE
Remove manifest target settings

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -41,9 +41,6 @@ let package = Package(
                 "BlackBox",
                 .product(name: "FirebasePerformance", package: "firebase-ios-sdk"),
                 .product(name: "DBThreadSafe", package: "DBThreadSafe-ios")
-            ],
-            swiftSettings: [
-                .treatAllWarnings(as: .error)
             ]
         ),
         .testTarget(
@@ -52,9 +49,6 @@ let package = Package(
                 .targetItem(name: targetName, condition: nil),
                 "BlackBox",
                 .product(name: "FirebasePerformance", package: "firebase-ios-sdk")
-            ],
-            swiftSettings: [
-                .treatAllWarnings(as: .error)
             ]
         ),
     ],


### PR DESCRIPTION
## Summary
- remove manifest-level treatAllWarnings(as: .error) from Package.swift
- unblock consumers from pinning a raw commit for this fix

## Validation
- swift test
